### PR TITLE
you can now set ssl key/crt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,34 @@
       line="host  replication  all  0.0.0.0/0  trust"
       regexp='^host  replication  all.*$'
 
+  # a few clever config changes.
+  - name: set max wal segments
+    sudo: true
+    lineinfile: >
+      dest={{pg_config_postgresql_conf}}
+      line="wal_keep_segments = 400"
+      regexp='^wal_keep_segments.*$'
+
+  - name: turn on ssl
+    sudo: true
+    lineinfile: >
+      dest={{pg_config_postgresql_conf}}
+      line="ssl = on"
+      regexp='^ssl.*=.*$'
+
+  - name: set ssl crt
+    sudo: true
+    lineinfile: >
+      dest={{pg_config_postgresql_conf}}
+      line="ssl_cert_file = '{{pg_config_ssl_cert_file}}'"
+      regexp='^ssl_cert_file.*=.*$'
+
+  - name: set ssl key
+    sudo: true
+    lineinfile: >
+      dest={{pg_config_postgresql_conf}}
+      line="ssl_key_file = '{{pg_config_ssl_key_file}}'"
+      regexp='^ssl_key_file.*=.*$'
 
   - name: setup passwordless ssh between pg nodes
     include: 'ssh-access.yml'

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -38,13 +38,6 @@
   sudo: true
   lineinfile: >
     dest={{pg_config_postgresql_conf}}
-    line="wal_keep_segments = 5000"
-    regexp='^wal_keep_segments.*$'
-
-- name: updating postgresql.conf
-  sudo: true
-  lineinfile: >
-    dest={{pg_config_postgresql_conf}}
     line="hot_standby = on"
     regexp='^hot_standby.*$'
 

--- a/templates/repmgr.conf.j2
+++ b/templates/repmgr.conf.j2
@@ -1,7 +1,7 @@
 cluster=master
 node={{node}}
 node_name={{ansible_hostname}}
-conninfo='host={{inventory_hostname}} dbname=repmgr user=postgres port=5432'
+conninfo='host={{inventory_hostname}} dbname=repmgr user=postgres port=5432{% if pg_config_secure %} sslmode=require{% endif %}'
 master_response_timeout=60
 reconnect_attempts=10
 reconnect_interval=30

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,6 +4,9 @@ postgresql_conf_directory: "/etc/postgresql/{{postgresql_version}}/{{postgresql_
 pg_config_postgresql_conf: "{{postgresql_conf_directory}}/postgresql.conf"
 pg_config_pg_hba_conf: "{{postgresql_conf_directory}}/pg_hba.conf"
 pg_config_repmgr_funcs: /usr/share/postgresql/9.3/contrib/repmgr_funcs.sql
+pg_config_secure: True
+pg_config_ssl_cert_file: '/foo/bar/fake.crt'
+pg_config_ssl_key_file: '/foo/bar/fake.pem'
 
 # shared public/secret key for replication between pg servers.
 pg_config_public_key: ssh-rsa not-a-real-key


### PR DESCRIPTION
- you can now set an ssl key/crt for replication.
- decreased max_wal_segments, hopefully we'll fill up the disk less fast.
