### PR TITLE
recovery.conf AKA, the source of all our pain

### DIFF
--- a/tasks/replica.yml
+++ b/tasks/replica.yml
@@ -6,5 +6,26 @@
   with_items:
     - "service postgresql stop"
     - "repmgr -R root -d repmgr -U postgres -h {{master_host}} standby clone --force"
+
+- name: ensure postgres connection is ssl
+  sudo: true
+  lineinfile: >
+    dest="{{postgresql_data_directory}}/recovery.conf"
+    line="primary_conninfo = 'port=5432 host={{master_host}} user=postgres sslmode=require'"
+    regexp='^primary_conninfo =.*$'
+  when: pg_config_secure
+
+- name: truncate WAL files on secondary
+  sudo: true
+  lineinfile: >
+    dest="{{postgresql_data_directory}}/recovery.conf"
+    line="archive_cleanup_command = 'pg_archivecleanup /mnt/postgresql/pg_xlog %r'"
+    regexp='^primary_conninfo =.*$'
+
+- name: register and start replica
+  sudo: true
+  command: "{{item}}"
+  ignore_errors: true
+  with_items:
     - "service postgresql start"
     - "repmgr -f /etc/repmgr/repmgr.conf standby register"

--- a/tasks/replica.yml
+++ b/tasks/replica.yml
@@ -20,7 +20,7 @@
   lineinfile: >
     dest="{{postgresql_data_directory}}/recovery.conf"
     line="archive_cleanup_command = 'pg_archivecleanup /mnt/postgresql/pg_xlog %r'"
-    regexp='^primary_conninfo =.*$'
+    regexp='^archive_cleanup_command =.*$'
 
 - name: register and start replica
   sudo: true


### PR DESCRIPTION
on replicas important configuration information needs to be set in recovery.conf, rather than the usual suspect postgresql.conf.

I've added two lines to recovery.conf for disk-space/security reasons:
- `sslmode=require` ensures that replication between the secondary and primary server is now SSL.
- `archive_cleanup_command` ensures that WAL files on the replica are truncated, so that the disk don't fill up.
